### PR TITLE
binding.gyp - noed-addon-api include path to relative instead of absolute

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -27,7 +27,7 @@
         }],
       ],
       "include_dirs": [
-        "<!@(node -p \"require('node-addon-api').include\")"
+        "<!@(node -p \"require('path').relative(process.cwd(),require('node-addon-api').include.replace(/\\\"/g,''))\")"
       ],
       'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS' ],
     }


### PR DESCRIPTION
so it node-gyp build wont break building in a directory with spaces or other special characters